### PR TITLE
Reassign "n_pairs" parameter in CCL method given some circuit property

### DIFF
--- a/qermit/clifford_noise_characterisation/ccl.py
+++ b/qermit/clifford_noise_characterisation/ccl.py
@@ -69,6 +69,7 @@ def sample_weighted_clifford_angle(rz_angle: float, **kwargs) -> float:
     """
     if "seed" in kwargs:
         random.seed(kwargs.get("seed"))
+        np.random.seed(kwargs.get("seed"))
 
     rz_angle = rz_angle % 2
     rz_angle_matrix = np.asarray(
@@ -164,9 +165,10 @@ def gen_state_circuits(
     # therefore, there must be another Clifford gates remaining to produce all pairs
     # this doesn't throw an error as this threshold is hard to predict in advance
     max_non_cliffs = min(len(rz_ops) - n_pairs, n_non_cliffords)
+    n_pairs = min(n_pairs, max_non_cliffs)
     # non_cliffords are indices for gates to be left non Clifford
 
-    non_cliffords = set(random.sample(rz_ops, max_non_cliffs))
+    non_cliffords = np.random.choice(list(rz_ops), max_non_cliffs)
     # rz_ops then only contains rz gates in c to be substituted for Clifford angles
     rz_ops.difference_update(non_cliffords)
     # Power of random Clifford gates to be substituted
@@ -178,9 +180,9 @@ def gen_state_circuits(
     while len(state_circuits) < total_state_circuits:
         # cliffords.keys() are integers for now Clifford gates
         # sample some set of these to be subbed for original non-Clifford angle
-        clifford_pair_elements = set(random.sample(cliffords.keys(), n_pairs))
+        clifford_pair_elements = random.sample(list(cliffords.keys()), n_pairs)
         # from remaining non-Clifford Rz gates, sample some to have random Clifford gate
-        non_clifford_pair_elements = set(random.sample(non_cliffords, n_pairs))
+        non_clifford_pair_elements = random.sample(list(non_cliffords), n_pairs)
 
         # create new Circuit from scratch
         new_circuit = Circuit(c.n_qubits, len(c.bits))

--- a/tests/ccl_test.py
+++ b/tests/ccl_test.py
@@ -71,20 +71,20 @@ def test_gen_state_circuits():
     s_2_coms = state_circuits0[2].get_commands()
     # manually assert angles of gates are expected for given state circuits for given seed
     # state circuit 0
-    assert s_0_coms[1].op.params == [0.5]
-    assert s_0_coms[3].op.params == [0.5]
-    assert s_0_coms[4].op.params == [0.5]
-    assert s_0_coms[5].op.params == [0.1]
+    assert s_0_coms[1].op.params == [0.63]
+    assert s_0_coms[3].op.params == [1.0]
+    assert s_0_coms[4].op.params == [0.0]
+    assert s_0_coms[5].op.params == [0.5]
     # state circuit 1
-    assert s_1_coms[1].op.params == [0.5]
-    assert s_1_coms[3].op.params == [0.9]
-    assert s_1_coms[4].op.params == [0.5]
-    assert s_1_coms[5].op.params == [0]
+    assert s_1_coms[1].op.params == [2.0]
+    assert s_1_coms[3].op.params == [0.5]
+    assert s_1_coms[4].op.params == [0.0]
+    assert s_1_coms[5].op.params == [0.1]
     # state circuit 2
-    assert s_2_coms[1].op.params == [0.5]
-    assert s_2_coms[3].op.params == [0.9]
-    assert s_2_coms[4].op.params == [0.5]
-    assert s_2_coms[5].op.params == [0]
+    assert s_2_coms[1].op.params == [2.0]
+    assert s_2_coms[3].op.params == [1.0]
+    assert s_2_coms[4].op.params == [0.2]
+    assert s_2_coms[5].op.params == [0.5]
 
     rz_counts_0 = count_rzs(state_circuits0[0])
     # 0th element number of rz cliffs, 1st element number of rz non cliffs


### PR DESCRIPTION
A given circuit you want to run CDR with will have some K gates which are non Clifford.
The n_non_cliffords parameter M dictates the number of these K gates you keep as their non Clifford angle for each characterisation circuit. So M <= K (though preferably less).
The n_pairs parameters P broadly dictates the number of these M gates you resample each time you create a new characterisation circuit. So P <= K.
If K < P or K < M, the method will now reassign P and M to respect the required constraints.