### PR TITLE
Use experiment mitres for folded experiments

### DIFF
--- a/qermit/taskgraph/task_graph.py
+++ b/qermit/taskgraph/task_graph.py
@@ -239,7 +239,7 @@ class TaskGraph:
 
                     # These two cases imply faulty TaskGraph construction
                     # Note that this check is only made as this is necessary constraint for decomposing TaskGraph nodes
-                    # Faulty construction should be caughty at construction of TaskGraph object, including types
+                    # Faulty construction should be caught at construction of TaskGraph object, including types
                     if len(task_in_edges) != len(task_input_out_edges):
                         raise TypeError(
                             "Decomposition of TaskGraph node {} not permitted: node "
@@ -251,7 +251,7 @@ class TaskGraph:
                         raise TypeError(
                             "Decomposition of TaskGraph node {} not permitted: task_graph "
                             "expects {} output wires but node returns {}.".format(
-                                task, len(task_input_out_edges), len(task_in_edges)
+                                task, len(task_output_in_edges), len(task_out_edges)
                             )
                         )
 

--- a/qermit/zero_noise_extrapolation/zne.py
+++ b/qermit/zero_noise_extrapolation/zne.py
@@ -737,13 +737,25 @@ def gen_ZNE_MitEx(backend: Backend, noise_scaling_list: List[float], **kwargs) -
 
         _label = str(fold) + "FoldMitEx"
 
-        fold_mitex = copy.copy(MitEx(backend, _label=_label, mitres=_experiment_mitres))
+        _fold_mitres = copy.copy(
+            kwargs.get(
+                "experiment_mitres",
+                MitRes(backend),
+            )
+        )
+
+        _fold_mitex = copy.copy(
+            kwargs.get(
+                "experiment_mitex",
+                MitEx(backend, _label=_label, mitres=_fold_mitres),
+            )
+        )
 
         digital_folding_task = digital_folding_task_gen(
             backend, fold, _folding_type, _allow_approx_fold
         )
-        fold_mitex.prepend(digital_folding_task)
-        _experiment_taskgraph.parallel(fold_mitex)
+        _fold_mitex.prepend(digital_folding_task)
+        _experiment_taskgraph.parallel(_fold_mitex)
 
     extrapolation_task = extrapolation_task_gen(
         noise_scaling_list, _fit_type, _show_fit, _deg

--- a/qermit/zero_noise_extrapolation/zne.py
+++ b/qermit/zero_noise_extrapolation/zne.py
@@ -737,11 +737,7 @@ def gen_ZNE_MitEx(backend: Backend, noise_scaling_list: List[float], **kwargs) -
 
         _label = str(fold) + "FoldMitEx"
 
-        fold_mitex = copy.copy(
-            kwargs.get(
-                "fold_mitex", MitEx(backend, _label=_label, mitres=MitRes(backend))
-            )
-        )
+        fold_mitex = copy.copy(MitEx(backend, _label=_label, mitres=_experiment_mitres))
 
         digital_folding_task = digital_folding_task_gen(
             backend, fold, _folding_type, _allow_approx_fold

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pytket>=0.13.0
+pytket==0.13.0
 matplotlib
 networkx

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -1,2 +1,3 @@
 pytket-qiskit>=0.15.1
+pytket==0.13
 pytest


### PR DESCRIPTION
This uses the user inputted Mitres for the fold mitex. This correct a bug that used a new mires instead.