### PR TITLE
Initialise exponential to intersect at noisy value

### DIFF
--- a/qermit/zero_noise_extrapolation/zne.py
+++ b/qermit/zero_noise_extrapolation/zne.py
@@ -340,11 +340,17 @@ class Fit(Enum):
             [-1, -2, *[-np.inf for i in range(deg)]],
             [1, 2, *[np.inf for i in range(deg)]],
         )
+ 
+        # Initialise decaying poly-exponential with intersect at 
+        # unfolded noisy value.
+        least_noisy_y_index = x.index(1)
+        p0 = [0, y[least_noisy_y_index], *[-1 for i in range(deg)]]
+
         vals = curve_fit(
             poly_exp_func,
             x,
             y,
-            p0=[0, 1, *[-1 for i in range(deg)]],
+            p0=p0,
             maxfev=10000,
             bounds=bounds,
         )


### PR DESCRIPTION
A small change which ensures that the initial poly-exponential used during fitting is decaying to 0 and intersects at the unfolded noisy value. This provides a small improvement when fitting.