### PR TITLE
Repair cdr training circ sampling

### DIFF
--- a/qermit/clifford_noise_characterisation/ccl.py
+++ b/qermit/clifford_noise_characterisation/ccl.py
@@ -184,7 +184,7 @@ def gen_state_circuits(
     n_pairs = min(n_cliffords, n_non_cliffords, n_pairs)
 
     # non_cliffords are indices for gates to be left non Clifford
-    non_cliffords = np.random.choice(list(rz_ops), n_non_cliffords)
+    non_cliffords = np.random.choice(list(rz_ops), n_non_cliffords, replace=False)
 
     # rz_ops then only contains rz gates in c to be substituted for Clifford angles
     rz_ops.difference_update(non_cliffords)

--- a/qermit/clifford_noise_characterisation/ccl.py
+++ b/qermit/clifford_noise_characterisation/ccl.py
@@ -136,7 +136,7 @@ def gen_state_circuits(
     all_coms = c.get_commands()
 
     #  angles that make Clifford gates for S^n
-    clifford_angles = set({0.5, 1.0, 1.5, 0})
+    clifford_angles = set({0, 0.5, 1.0, 1.5, 2, 2.5, 3, 3.5})
 
     if n_pairs > n_non_cliffords:
         raise ValueError(

--- a/tests/ccl_test.py
+++ b/tests/ccl_test.py
@@ -60,7 +60,7 @@ def count_rzs(circuit):
 
 def test_gen_state_circuits():
     # create dummy test circuit
-    c = Circuit(4).Rz(0.9, 3).Rz(0.63, 1).Rx(0.2, 0).Rx(0.1, 2)
+    c = Circuit(4).Rz(0.9, 3).Rz(0.63, 1).Rx(0.2, 0).Rx(0.1, 2).Rz(3, 1)
     state_circuits0 = gen_state_circuits(
         c, n_non_cliffords=1, n_pairs=1, total_state_circuits=3, seed=197
     )
@@ -73,24 +73,24 @@ def test_gen_state_circuits():
     # manually assert angles of gates are expected for given state circuits for given seed
     # state circuit 0
     assert s_0_coms[5].op.params == [0.63]
-    assert s_0_coms[7].op.params == [1.0]
+    assert s_0_coms[7].op.params == [0.0]
     assert s_0_coms[8].op.params == [0.0]
     assert s_0_coms[10].op.params == [0.5]
     # state circuit 1
     assert s_1_coms[5].op.params == [2.0]
-    assert s_1_coms[7].op.params == [0.5]
+    assert s_1_coms[7].op.params == [0.0]
     assert s_1_coms[8].op.params == [0.0]
     assert s_1_coms[10].op.params == [0.1]
     # state circuit 2
     assert s_2_coms[5].op.params == [2.0]
-    assert s_2_coms[7].op.params == [1.0]
-    assert s_2_coms[8].op.params == [0.2]
+    assert s_2_coms[7].op.params == [0.9]
+    assert s_2_coms[8].op.params == [0.0]
     assert s_2_coms[10].op.params == [0.5]
 
     rz_counts_0 = count_rzs(state_circuits0[0])
     # 0th element number of rz cliffs, 1st element number of rz non cliffs
     assert rz_counts_0[0] == 3
-    assert rz_counts_0[1] == 1
+    assert rz_counts_0[1] == 2
 
     state_circuits1 = gen_state_circuits(
         c, n_non_cliffords=2, n_pairs=2, total_state_circuits=2, seed=197
@@ -98,9 +98,9 @@ def test_gen_state_circuits():
     rz_counts_10 = count_rzs(state_circuits1[0])
     rz_counts_11 = count_rzs(state_circuits1[1])
     assert rz_counts_10[0] == 2
-    assert rz_counts_10[1] == 2
+    assert rz_counts_10[1] == 3
     assert rz_counts_11[0] == 2
-    assert rz_counts_11[1] == 2
+    assert rz_counts_11[1] == 3
 
     big_c = Circuit(10)
     for _ in range(10):


### PR DESCRIPTION
This PR:
- Extends Clifford angles to include double rotation.
- Samples gates to be left non Clifford without replacement
This corrects a mismatch between the number of non-Clifford circuits requested, and the number actually left in the circuit.