### PR TITLE
Allow for Barriers when performing ZNE folding

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Run mypy
       if: github.event_name == 'pull_request'
       run: |
-        python3 -m pip install -U mypy
+        python3 -m pip install -U mypy==0.901
         mypy -p qermit 
     - name: Test qermit 
       if: github.event_name == 'pull_request'

--- a/qermit/zero_noise_extrapolation/zne.py
+++ b/qermit/zero_noise_extrapolation/zne.py
@@ -77,7 +77,6 @@ class Folding(Enum):
                     folded_circ.add_barrier(gate.args)
                 else:
                     folded_circ.add_gate(gate.op.dagger, gate.args)
-            # folded_circ.add_circuit(circ.dagger(), folded_circ.qubits, folded_circ.bits)
 
             # Add barrier between circuit and its inverse
             folded_circ.add_barrier(folded_circ.qubits + folded_circ.bits)
@@ -115,10 +114,14 @@ class Folding(Enum):
         num_commands = len(c_dict["commands"])
 
         # Count and locate the number of commands that are not barriers
-        c_dict_commands_non_barrier = [(i, command) for (i, command) in enumerate(c_dict['commands']) if command['op']['type'] != 'Barrier']
+        c_dict_commands_non_barrier = [
+            (i, command)
+            for (i, command) in enumerate(c_dict["commands"])
+            if command["op"]["type"] != "Barrier"
+        ]
         num_non_barrier_commands = len(c_dict_commands_non_barrier)
 
-        # Calculate the number of gates that need to be folded. Note that only 
+        # Calculate the number of gates that need to be folded. Note that only
         # non barrier commands should be folded so only these are counted.
         num_additional_commands = (noise_scaling - 1) * num_non_barrier_commands
         num_folded_commands = int(num_additional_commands // 2)
@@ -135,7 +138,7 @@ class Folding(Enum):
             )
 
         # Choose a random selection of commands to fold. Commands are referenced by their index.
-        # These are chosen with replacement. Only non barrier commands should 
+        # These are chosen with replacement. Only non barrier commands should
         # be folded, and so only the index of those are added here.
         commands_to_fold = np.random.choice(
             [i[0] for i in c_dict_commands_non_barrier], num_folded_commands
@@ -155,8 +158,8 @@ class Folding(Enum):
             command_circ_dict.update({"commands": [command]})
             command_circ = Circuit().from_dict(command_circ_dict)
 
-            # Commands which are not to be folded may not be invertible (for 
-            # example barriers) and so the inverse is not calculated in that 
+            # Commands which are not to be folded may not be invertible (for
+            # example barriers) and so the inverse is not calculated in that
             # case.
             if num_folds[command_index] > 0:
                 # Find the inverse of the command
@@ -218,9 +221,9 @@ class Folding(Enum):
 
         for command in c_dict["commands"]:
 
-            # Barriers are added to the circuit but otherwise effectively 
+            # Barriers are added to the circuit but otherwise effectively
             # skipped.
-            if command['op']['type'] == 'Barrier':
+            if command["op"]["type"] == "Barrier":
 
                 folded_command_list.append(command)
 

--- a/qermit/zero_noise_extrapolation/zne.py
+++ b/qermit/zero_noise_extrapolation/zne.py
@@ -28,7 +28,7 @@ from enum import Enum
 import numpy as np
 from scipy.optimize import curve_fit  # type: ignore
 from typing import List, Tuple, cast
-from pytket import Circuit
+from pytket import Circuit, OpType
 from pytket.predicates import CompilationUnit  # type: ignore
 from pytket.utils import QubitPauliOperator
 import matplotlib.pyplot as plt  # type: ignore
@@ -70,9 +70,19 @@ class Folding(Enum):
 
             # Add barrier between circuit and its inverse
             folded_circ.add_barrier(folded_circ.qubits + folded_circ.bits)
-            folded_circ.add_circuit(circ.dagger(), folded_circ.qubits, folded_circ.bits)
 
+            # Add inverse circuit by iterating though commands and inverting them
+            for gate in reversed(circ.get_commands()):
+                if gate.op.type == OpType.Barrier:
+                    folded_circ.add_barrier(gate.args)
+                else:
+                    folded_circ.add_gate(gate.op.dagger, gate.args)
+            # folded_circ.add_circuit(circ.dagger(), folded_circ.qubits, folded_circ.bits)
+
+            # Add barrier between circuit and its inverse
             folded_circ.add_barrier(folded_circ.qubits + folded_circ.bits)
+
+            # Add original circuit
             folded_circ.add_circuit(circ, folded_circ.qubits, folded_circ.bits)
 
         return folded_circ

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pytket~=0.16.0
+pytket~=0.17.0
 matplotlib
 networkx

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -1,3 +1,3 @@
 pytket-qiskit~=0.19.0
-pytket~=0.16.0
+pytket~=0.17.0
 pytest

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -1,3 +1,3 @@
-pytket-qiskit~=0.19.0
+pytket-qiskit~=0.20.0
 pytket~=0.17.0
 pytest

--- a/tests/zne_test.py
+++ b/tests/zne_test.py
@@ -196,10 +196,18 @@ def test_digital_folding_task_gen():
         be, be._rebase_pass, n_folds_2, Folding.gate, _allow_approx_fold=False
     )
     task_3 = digital_folding_task_gen(
-        noisy_backend, noisy_backend._rebase_pass, n_folds_3, Folding.gate, _allow_approx_fold=False
+        noisy_backend,
+        noisy_backend._rebase_pass,
+        n_folds_3,
+        Folding.gate,
+        _allow_approx_fold=False,
     )
     task_4 = digital_folding_task_gen(
-        noisy_backend, noisy_backend._rebase_pass, n_folds_4, Folding.odd_gate, _allow_approx_fold=False
+        noisy_backend,
+        noisy_backend._rebase_pass,
+        n_folds_4,
+        Folding.odd_gate,
+        _allow_approx_fold=False,
     )
 
     assert task_1.n_in_wires == 1
@@ -215,7 +223,7 @@ def test_digital_folding_task_gen():
     c_2 = Circuit(2).CZ(0, 1).T(0).X(1)
     c_3 = Circuit(2).CX(0, 1).H(0).Rx(0.3, 1).Rz(0.6, 1)
     c_4 = Circuit(2).CX(0, 1).H(0).Rz(0.3, 1)
-    c_5 = Circuit(2).H(0).add_barrier([0,1]).CX(0,1)
+    c_5 = Circuit(2).H(0).add_barrier([0, 1]).CX(0, 1)
 
     ac_1 = AnsatzCircuit(c_1, 10000, {})
     ac_2 = AnsatzCircuit(c_2, 10000, {})
@@ -269,8 +277,16 @@ def test_digital_folding_task_gen():
     assert folded_c_3.n_gates == c_3.n_gates * n_folds_3 + c_3.n_gates * (n_folds_3 - 1)
     assert folded_c_4.n_gates == c_4.n_gates + n_folds_4 * 2 * ((c_4.n_gates + 1) // 2)
     assert folded_c_5.n_gates == c_5.n_gates * n_folds_1 + n_folds_1 - 1
-    assert folded_c_6.n_gates == (c_5.n_gates - c_5.n_gates_of_type(OpType.Barrier)) * n_folds_2 + (c_5.n_gates - c_5.n_gates_of_type(OpType.Barrier)) * (n_folds_2 - 1) + c_5.n_gates_of_type(OpType.Barrier)
-    assert folded_c_7.n_gates == c_5.n_gates + n_folds_4 * 2 * (((c_5.n_gates-c_5.n_gates_of_type(OpType.Barrier)) + 1) // 2)
+    assert folded_c_6.n_gates == (
+        c_5.n_gates - c_5.n_gates_of_type(OpType.Barrier)
+    ) * n_folds_2 + (c_5.n_gates - c_5.n_gates_of_type(OpType.Barrier)) * (
+        n_folds_2 - 1
+    ) + c_5.n_gates_of_type(
+        OpType.Barrier
+    )
+    assert folded_c_7.n_gates == c_5.n_gates + n_folds_4 * 2 * (
+        ((c_5.n_gates - c_5.n_gates_of_type(OpType.Barrier)) + 1) // 2
+    )
 
     c_1_unitary = c_1.get_unitary()
     c_2_unitary = c_2.get_unitary()
@@ -298,7 +314,13 @@ def test_zne_identity():
 
     backend = AerBackend()
 
-    me = gen_ZNE_MitEx(backend, backend._rebase_pass, [7, 5, 3], _label="TestZNEMitEx", optimisation_level=0)
+    me = gen_ZNE_MitEx(
+        backend,
+        backend._rebase_pass,
+        [7, 5, 3],
+        _label="TestZNEMitEx",
+        optimisation_level=0,
+    )
 
     c = Circuit(3)
     for _ in range(10):

--- a/tests/zne_test.py
+++ b/tests/zne_test.py
@@ -215,11 +215,13 @@ def test_digital_folding_task_gen():
     c_2 = Circuit(2).CZ(0, 1).T(0).X(1)
     c_3 = Circuit(2).CX(0, 1).H(0).Rx(0.3, 1).Rz(0.6, 1)
     c_4 = Circuit(2).CX(0, 1).H(0).Rz(0.3, 1)
+    c_5 = Circuit(2).H(0).add_barrier([0,1]).CX(0,1)
 
     ac_1 = AnsatzCircuit(c_1, 10000, {})
     ac_2 = AnsatzCircuit(c_2, 10000, {})
     ac_3 = AnsatzCircuit(c_3, 10000, {})
     ac_4 = AnsatzCircuit(c_4, 10000, {})
+    ac_5 = AnsatzCircuit(c_5, 10000, {})
 
     qpo_1 = QubitPauliOperator({QubitPauliString([Qubit(0)], [Pauli.Z]): 1})
     qpo_2 = QubitPauliOperator({QubitPauliString([Qubit(1)], [Pauli.Z]): 1})
@@ -232,22 +234,26 @@ def test_digital_folding_task_gen():
     experiment_2 = ObservableExperiment(ac_2, ObservableTracker(qpo_2))
     experiment_3 = ObservableExperiment(ac_3, ObservableTracker(qpo_3))
     experiment_4 = ObservableExperiment(ac_4, ObservableTracker(qpo_4))
+    experiment_5 = ObservableExperiment(ac_5, ObservableTracker(qpo_3))
 
     folded_experiment_1 = task_1([[experiment_1]])[0][0]
     folded_experiment_2 = task_2([[experiment_2]])[0][0]
     folded_experiment_3 = task_3([[experiment_3]])[0][0]
     folded_experiment_4 = task_4([[experiment_4]])[0][0]
+    folded_experiment_5 = task_1([[experiment_5]])[0][0]
 
     folded_c_1 = folded_experiment_1[0][0]
     folded_c_2 = folded_experiment_2[0][0]
     folded_c_3 = folded_experiment_3[0][0]
     folded_c_4 = folded_experiment_4[0][0]
+    folded_c_5 = folded_experiment_5[0][0]
 
     # TODO: Add a backend with a more restricted gateset
     assert GateSetPredicate(be.backend_info.gate_set).verify(folded_c_1)
     assert GateSetPredicate(be.backend_info.gate_set).verify(folded_c_2)
     assert GateSetPredicate(noisy_backend.backend_info.gate_set).verify(folded_c_3)
     assert GateSetPredicate(noisy_backend.backend_info.gate_set).verify(folded_c_4)
+    assert GateSetPredicate(be.backend_info.gate_set).verify(folded_c_5)
 
     # Checks that the number of gates has been increased correctly.
     # Note that in both cases barriers are added. This is why there is the
@@ -256,20 +262,24 @@ def test_digital_folding_task_gen():
     assert folded_c_2.n_gates == c_2.n_gates * n_folds_2 + c_2.n_gates * (n_folds_2 - 1)
     assert folded_c_3.n_gates == c_3.n_gates * n_folds_3 + c_3.n_gates * (n_folds_3 - 1)
     assert folded_c_4.n_gates == c_4.n_gates + n_folds_4 * (2 * (c_4.n_gates + 1) // 2)
+    assert folded_c_5.n_gates == c_5.n_gates * n_folds_1 + n_folds_1 - 1
 
     c_1_unitary = c_1.get_unitary()
     c_2_unitary = c_2.get_unitary()
     c_3_unitary = c_3.get_unitary()
     c_4_unitary = c_4.get_unitary()
+    c_5_unitary = c_5.get_unitary()
     folded_c_1_unitary = folded_c_1.get_unitary()
     folded_c_2_unitary = folded_c_2.get_unitary()
     folded_c_3_unitary = folded_c_3.get_unitary()
     folded_c_4_unitary = folded_c_4.get_unitary()
+    folded_c_5_unitary = folded_c_5.get_unitary()
 
     assert np.allclose(c_1_unitary, folded_c_1_unitary)
     assert np.allclose(c_2_unitary, folded_c_2_unitary)
     assert np.allclose(c_3_unitary, folded_c_3_unitary)
     assert np.allclose(c_4_unitary, folded_c_4_unitary)
+    assert np.allclose(c_5_unitary, folded_c_5_unitary)
 
 
 def test_zne_identity():

--- a/tests/zne_test.py
+++ b/tests/zne_test.py
@@ -241,12 +241,14 @@ def test_digital_folding_task_gen():
     folded_experiment_3 = task_3([[experiment_3]])[0][0]
     folded_experiment_4 = task_4([[experiment_4]])[0][0]
     folded_experiment_5 = task_1([[experiment_5]])[0][0]
+    folded_experiment_6 = task_2([[experiment_5]])[0][0]
 
     folded_c_1 = folded_experiment_1[0][0]
     folded_c_2 = folded_experiment_2[0][0]
     folded_c_3 = folded_experiment_3[0][0]
     folded_c_4 = folded_experiment_4[0][0]
     folded_c_5 = folded_experiment_5[0][0]
+    folded_c_6 = folded_experiment_6[0][0]
 
     # TODO: Add a backend with a more restricted gateset
     assert GateSetPredicate(be.backend_info.gate_set).verify(folded_c_1)
@@ -254,6 +256,7 @@ def test_digital_folding_task_gen():
     assert GateSetPredicate(noisy_backend.backend_info.gate_set).verify(folded_c_3)
     assert GateSetPredicate(noisy_backend.backend_info.gate_set).verify(folded_c_4)
     assert GateSetPredicate(be.backend_info.gate_set).verify(folded_c_5)
+    assert GateSetPredicate(be.backend_info.gate_set).verify(folded_c_6)
 
     # Checks that the number of gates has been increased correctly.
     # Note that in both cases barriers are added. This is why there is the
@@ -263,6 +266,7 @@ def test_digital_folding_task_gen():
     assert folded_c_3.n_gates == c_3.n_gates * n_folds_3 + c_3.n_gates * (n_folds_3 - 1)
     assert folded_c_4.n_gates == c_4.n_gates + n_folds_4 * (2 * (c_4.n_gates + 1) // 2)
     assert folded_c_5.n_gates == c_5.n_gates * n_folds_1 + n_folds_1 - 1
+    assert folded_c_6.n_gates == (c_5.n_gates - c_5.n_gates_of_type(OpType.Barrier)) * n_folds_2 + (c_5.n_gates - c_5.n_gates_of_type(OpType.Barrier)) * (n_folds_2 - 1) + c_5.n_gates_of_type(OpType.Barrier)
 
     c_1_unitary = c_1.get_unitary()
     c_2_unitary = c_2.get_unitary()
@@ -274,12 +278,14 @@ def test_digital_folding_task_gen():
     folded_c_3_unitary = folded_c_3.get_unitary()
     folded_c_4_unitary = folded_c_4.get_unitary()
     folded_c_5_unitary = folded_c_5.get_unitary()
+    folded_c_6_unitary = folded_c_6.get_unitary()
 
     assert np.allclose(c_1_unitary, folded_c_1_unitary)
     assert np.allclose(c_2_unitary, folded_c_2_unitary)
     assert np.allclose(c_3_unitary, folded_c_3_unitary)
     assert np.allclose(c_4_unitary, folded_c_4_unitary)
     assert np.allclose(c_5_unitary, folded_c_5_unitary)
+    assert np.allclose(c_5_unitary, folded_c_6_unitary)
 
 
 def test_zne_identity():

--- a/tests/zne_test.py
+++ b/tests/zne_test.py
@@ -242,6 +242,7 @@ def test_digital_folding_task_gen():
     folded_experiment_4 = task_4([[experiment_4]])[0][0]
     folded_experiment_5 = task_1([[experiment_5]])[0][0]
     folded_experiment_6 = task_2([[experiment_5]])[0][0]
+    folded_experiment_7 = task_4([[experiment_5]])[0][0]
 
     folded_c_1 = folded_experiment_1[0][0]
     folded_c_2 = folded_experiment_2[0][0]
@@ -249,6 +250,7 @@ def test_digital_folding_task_gen():
     folded_c_4 = folded_experiment_4[0][0]
     folded_c_5 = folded_experiment_5[0][0]
     folded_c_6 = folded_experiment_6[0][0]
+    folded_c_7 = folded_experiment_7[0][0]
 
     # TODO: Add a backend with a more restricted gateset
     assert GateSetPredicate(be.backend_info.gate_set).verify(folded_c_1)
@@ -257,6 +259,7 @@ def test_digital_folding_task_gen():
     assert GateSetPredicate(noisy_backend.backend_info.gate_set).verify(folded_c_4)
     assert GateSetPredicate(be.backend_info.gate_set).verify(folded_c_5)
     assert GateSetPredicate(be.backend_info.gate_set).verify(folded_c_6)
+    assert GateSetPredicate(noisy_backend.backend_info.gate_set).verify(folded_c_7)
 
     # Checks that the number of gates has been increased correctly.
     # Note that in both cases barriers are added. This is why there is the
@@ -264,9 +267,10 @@ def test_digital_folding_task_gen():
     assert folded_c_1.n_gates == c_1.n_gates * n_folds_1 + n_folds_1 - 1
     assert folded_c_2.n_gates == c_2.n_gates * n_folds_2 + c_2.n_gates * (n_folds_2 - 1)
     assert folded_c_3.n_gates == c_3.n_gates * n_folds_3 + c_3.n_gates * (n_folds_3 - 1)
-    assert folded_c_4.n_gates == c_4.n_gates + n_folds_4 * (2 * (c_4.n_gates + 1) // 2)
+    assert folded_c_4.n_gates == c_4.n_gates + n_folds_4 * 2 * ((c_4.n_gates + 1) // 2)
     assert folded_c_5.n_gates == c_5.n_gates * n_folds_1 + n_folds_1 - 1
     assert folded_c_6.n_gates == (c_5.n_gates - c_5.n_gates_of_type(OpType.Barrier)) * n_folds_2 + (c_5.n_gates - c_5.n_gates_of_type(OpType.Barrier)) * (n_folds_2 - 1) + c_5.n_gates_of_type(OpType.Barrier)
+    assert folded_c_7.n_gates == c_5.n_gates + n_folds_4 * 2 * (((c_5.n_gates-c_5.n_gates_of_type(OpType.Barrier)) + 1) // 2)
 
     c_1_unitary = c_1.get_unitary()
     c_2_unitary = c_2.get_unitary()
@@ -279,6 +283,7 @@ def test_digital_folding_task_gen():
     folded_c_4_unitary = folded_c_4.get_unitary()
     folded_c_5_unitary = folded_c_5.get_unitary()
     folded_c_6_unitary = folded_c_6.get_unitary()
+    folded_c_7_unitary = folded_c_7.get_unitary()
 
     assert np.allclose(c_1_unitary, folded_c_1_unitary)
     assert np.allclose(c_2_unitary, folded_c_2_unitary)
@@ -286,6 +291,7 @@ def test_digital_folding_task_gen():
     assert np.allclose(c_4_unitary, folded_c_4_unitary)
     assert np.allclose(c_5_unitary, folded_c_5_unitary)
     assert np.allclose(c_5_unitary, folded_c_6_unitary)
+    assert np.allclose(c_5_unitary, folded_c_7_unitary)
 
 
 def test_zne_identity():


### PR DESCRIPTION
Here we allow for the inclusion of Barriers in circuits when using the ZNE folding methods. This circumvents the lack of a .dagger property in the Barrier op. This is necessary to make use of mirrored circuits, for example.