### PR TITLE
Allow barriers in CDR

### DIFF
--- a/qermit/clifford_noise_characterisation/ccl.py
+++ b/qermit/clifford_noise_characterisation/ccl.py
@@ -177,6 +177,9 @@ def gen_state_circuits(
                 # Measure gate has special case, but can assume 1 qubit to 1 bit
                 elif com.op.type is OpType.Measure:
                     new_circuit.Measure(com.qubits[0], com.bits[0])
+                # A special case for Barrier metaop
+                elif com.op.type == OpType.Barrier:
+                    new_circuit.add_barrier(com.args)
                 # CX or H gate, add as is
                 else:
                     new_circuit.add_gate(com.op.type, com.qubits)

--- a/qermit/clifford_noise_characterisation/ccl.py
+++ b/qermit/clifford_noise_characterisation/ccl.py
@@ -243,6 +243,9 @@ def gen_state_circuits(
             # Measure gate has special case, but can assume 1 qubit to 1 bit
             elif com.op.type is OpType.Measure:
                 new_circuit.Measure(com.qubits[0], com.bits[0])
+            # A special case for Barrier metaop
+            elif com.op.type == OpType.Barrier:
+                new_circuit.add_barrier(com.args)
             # CX or H gate, add as is
             else:
                 new_circuit.add_gate(com.op.type, com.qubits)

--- a/qermit/clifford_noise_characterisation/ccl.py
+++ b/qermit/clifford_noise_characterisation/ccl.py
@@ -39,7 +39,6 @@ import numpy as np
 import random
 from enum import Enum
 import warnings
-import math
 
 
 class LikelihoodFunction(Enum):

--- a/tests/ccl_test.py
+++ b/tests/ccl_test.py
@@ -149,7 +149,7 @@ def test_ccl_state_task_gen():
 
     c = Circuit(3).Rz(0.63, 1).Rz(0.2, 0).Rz(0.1, 2)
     c.Rz(0.43, 1).Rz(0.5, 0).Rz(0.8, 2)
-    c.Rz(1.23, 1).Rz(1.2, 0).Rz(1.1, 2)
+    c.Rz(1.23, 1).Rz(1.2, 0).add_barrier([0,1]).Rz(1.1, 2)
     c.Rz(9.63, 1).Rz(8.2, 0).Rz(10.1, 2)
 
     qps_012 = QubitPauliString(

--- a/tests/ccl_test.py
+++ b/tests/ccl_test.py
@@ -149,7 +149,7 @@ def test_ccl_state_task_gen():
 
     c = Circuit(3).Rz(0.63, 1).Rz(0.2, 0).Rz(0.1, 2)
     c.Rz(0.43, 1).Rz(0.5, 0).Rz(0.8, 2)
-    c.Rz(1.23, 1).Rz(1.2, 0).add_barrier([0,1]).Rz(1.1, 2)
+    c.Rz(1.23, 1).Rz(1.2, 0).add_barrier([0, 1]).Rz(1.1, 2)
     c.Rz(9.63, 1).Rz(8.2, 0).Rz(10.1, 2)
 
     qps_012 = QubitPauliString(

--- a/tests/cdr_test.py
+++ b/tests/cdr_test.py
@@ -153,3 +153,4 @@ def test_cdr_calibration_correction_task_gen():
 if __name__ == "__main__":
     test_linear_cdr_calib()
     test_cdr_calibration_correction_task_gen()
+    test_cdr_quality_check_task_gen()


### PR DESCRIPTION
Here we include a special case in the calibration circuit generation step which allows for barriers. Currently the catch all add_gate does not work for metaops.