### PR TITLE
ZNE Include all Qubit Map

### DIFF
--- a/qermit/zero_noise_extrapolation/zne.py
+++ b/qermit/zero_noise_extrapolation/zne.py
@@ -971,7 +971,7 @@ def gen_qubit_relabel_task() -> MitTask:
 
         :param qpo_list: List of QubitPauliOperator
         :type qpo_list: List[QubitPauliOperator]
-        :param compilation_map: List of Dictionaries mapping nodes as
+        :param compilation_map_list: List of Dictionaries mapping nodes as
             returned by gen_initial_compilation_task task
         :type compilation_map_list: List[Dict[Node, Node]]
         :return: List of QubitPauliOperator with relabeled nodes.

--- a/qermit/zero_noise_extrapolation/zne.py
+++ b/qermit/zero_noise_extrapolation/zne.py
@@ -899,19 +899,20 @@ def gen_initial_compilation_task(
 
     def task(
         obj, wire: List[ObservableExperiment]
-    ) -> Tuple[List[ObservableExperiment], Dict[Node, Node]]:
+    ) -> Tuple[List[ObservableExperiment], List[Dict[Node, Node]]]:
         """Performs initial compilation before folding. This is to ensure minimal compilation
         after folding, as this could disrupt by how much the noise is increased.
 
         :param wire: List of experiments
         :type wire: List[ObservableExperiment]
         :return: List of experiments compiled to run on the inputted backend.
-        Additionally a dictionary describing how the nodes have been mapped
-        by compilation.
-        :rtype: Tuple[List[ObservableExperiment], Dict[Node, Node]]
+            Additionally a list of dictionaries describing how the nodes have
+            been mapped by compilation.
+        :rtype: Tuple[List[ObservableExperiment], List[Dict[Node, Node]]]
         """
 
         mapped_wire = []
+        node_map_list = []
 
         for obs_exp in wire:
             # Perform default compilation, tracking to which physical
@@ -923,6 +924,7 @@ def gen_initial_compilation_task(
                 optimisation_level=optimisation_level
             ).apply(cu)
             node_map = cu.final_map
+            node_map_list.append(node_map)
 
             # Alter the qubit pauli operator so that it maps to the new physical qubits.
             qpo = obs_exp[1]._qubit_pauli_operator
@@ -942,7 +944,7 @@ def gen_initial_compilation_task(
 
         return (
             mapped_wire,
-            node_map,
+            node_map_list,
         )
 
     return MitTask(
@@ -962,22 +964,26 @@ def gen_qubit_relabel_task() -> MitTask:
     """
 
     def task(
-        obj, qpo_list: List[QubitPauliOperator], compilation_map: Dict[Node, Node]
+        obj, qpo_list: List[QubitPauliOperator], compilation_map_list: List[Dict[Node, Node]]
     ) -> Tuple[List[QubitPauliOperator]]:
         """Use node map returned by compilation unit to undo the relabelling
         performed by gen_initial_compilation_task
 
         :param qpo_list: List of QubitPauliOperator
         :type qpo_list: List[QubitPauliOperator]
-        :param compilation_map: Dictionary mapping nodes as returned by
-        gen_initial_compilation_task task
-        :type compilation_map: Dict[Node, Node]
+        :param compilation_map: List of Dictionaries mapping nodes as
+            returned by gen_initial_compilation_task task
+        :type compilation_map_list: List[Dict[Node, Node]]
         :return: List of QubitPauliOperator with relabeled nodes.
         :rtype: Tuple[List[QubitPauliOperator]]
         """
 
-        node_map = {value: key for key, value in compilation_map.items()}
-        new_qpo_list = [qpo_node_relabel(qpo, node_map) for qpo in qpo_list]
+        new_qpo_list = []
+
+        for compilation_map, qpo in zip(compilation_map_list, qpo_list):
+
+            node_map = {value: key for key, value in compilation_map.items()}
+            new_qpo_list.append(qpo_node_relabel(qpo, node_map))
 
         return (new_qpo_list,)
 

--- a/tests/zne_test.py
+++ b/tests/zne_test.py
@@ -107,7 +107,7 @@ def test_gen_qubit_relabel_task():
     )
     qubit_pauli_operator = QubitPauliOperator({qubit_pauli_string: 1.0})
 
-    compilation_map = {Node(0): Qubit(0), Node(1): Qubit(1), Node(2): Qubit(2)}
+    compilation_map = [{Node(0): Qubit(0), Node(1): Qubit(1), Node(2): Qubit(2)}]
 
     relabeled_qubit_pauli_string = QubitPauliString(
         [Node(0), Node(1), Node(2)], [Pauli.Z, Pauli.Z, Pauli.Z]
@@ -467,8 +467,8 @@ def test_simple_run_end_to_end():
     expectation_1 = result[0]
     expectation_2 = result[1]
 
-    res1 = expectation_1[QubitPauliString([Qubit(0)], [Pauli.Z])]
-    res2 = expectation_2[QubitPauliString([Qubit(1)], [Pauli.Z])]
+    res1 = expectation_1[QubitPauliString([Qubit(1)], [Pauli.Z])]
+    res2 = expectation_2[QubitPauliString([Qubit(0)], [Pauli.Z])]
 
     assert round(float(res1)) == 1.0
     assert round(float(res2)) == -1.0

--- a/tests/zne_test.py
+++ b/tests/zne_test.py
@@ -107,7 +107,7 @@ def test_gen_qubit_relabel_task():
     )
     qubit_pauli_operator = QubitPauliOperator({qubit_pauli_string: 1.0})
 
-    compilation_map = {Node(0): Qubit(0), Node(1): Qubit(1), Node(2): Qubit(2)}
+    compilation_map = [{Node(0): Qubit(0), Node(1): Qubit(1), Node(2): Qubit(2)}]
 
     relabeled_qubit_pauli_string = QubitPauliString(
         [Node(0), Node(1), Node(2)], [Pauli.Z, Pauli.Z, Pauli.Z]
@@ -130,13 +130,13 @@ def test_gen_initial_compilation_task():
     assert task.n_out_wires == 2
 
     c_1 = Circuit(2).CZ(0, 1).T(1)
-    c_2 = Circuit(2).CZ(0, 1).T(0).X(1)
+    c_2 = Circuit(1).T(0).X(0)
 
     ac_1 = AnsatzCircuit(c_1, 10000, {})
     ac_2 = AnsatzCircuit(c_2, 10000, {})
 
-    qpo_1 = QubitPauliOperator({QubitPauliString([Qubit(0)], [Pauli.Z]): 1})
-    qpo_2 = QubitPauliOperator({QubitPauliString([Qubit(1)], [Pauli.Z]): 1})
+    qpo_1 = QubitPauliOperator({QubitPauliString([Qubit(1)], [Pauli.Z]): 1})
+    qpo_2 = QubitPauliOperator({QubitPauliString([Qubit(0)], [Pauli.Z]): 1})
 
     experiment_1 = ObservableExperiment(ac_1, ObservableTracker(qpo_1))
     experiment_2 = ObservableExperiment(ac_2, ObservableTracker(qpo_2))

--- a/tests/zne_test.py
+++ b/tests/zne_test.py
@@ -107,7 +107,7 @@ def test_gen_qubit_relabel_task():
     )
     qubit_pauli_operator = QubitPauliOperator({qubit_pauli_string: 1.0})
 
-    compilation_map = [{Node(0): Qubit(0), Node(1): Qubit(1), Node(2): Qubit(2)}]
+    compilation_map = {Node(0): Qubit(0), Node(1): Qubit(1), Node(2): Qubit(2)}
 
     relabeled_qubit_pauli_string = QubitPauliString(
         [Node(0), Node(1), Node(2)], [Pauli.Z, Pauli.Z, Pauli.Z]
@@ -442,7 +442,7 @@ def test_simple_run_end_to_end():
     )
 
     c_1 = Circuit(2).CZ(0, 1).T(1)
-    c_2 = Circuit(2).CZ(0, 1).T(0).X(1)
+    c_2 = Circuit(1).T(0).X(0)
     ac_1 = AnsatzCircuit(c_1, 10000, SymbolsDict())
     ac_2 = AnsatzCircuit(c_2, 10000, SymbolsDict())
     circ_list = []
@@ -450,7 +450,7 @@ def test_simple_run_end_to_end():
         ObservableExperiment(
             ac_1,
             ObservableTracker(
-                QubitPauliOperator({QubitPauliString([Qubit(0)], [Pauli.Z]): 1})
+                QubitPauliOperator({QubitPauliString([Qubit(1)], [Pauli.Z]): 1})
             ),
         )
     )
@@ -458,7 +458,7 @@ def test_simple_run_end_to_end():
         ObservableExperiment(
             ac_2,
             ObservableTracker(
-                QubitPauliOperator({QubitPauliString([Qubit(1)], [Pauli.Z]): 1})
+                QubitPauliOperator({QubitPauliString([Qubit(0)], [Pauli.Z]): 1})
             ),
         )
     )


### PR DESCRIPTION
Corrects a bug resulting from not all qubit maps being stored during initial compilation.