### PR TITLE
Noise Aware ZNE

### DIFF
--- a/docs_src/zero_noise_extrapolation.rst
+++ b/docs_src/zero_noise_extrapolation.rst
@@ -5,7 +5,7 @@ qermit.zero_noise_extrapolation
 
 .. automethod:: qermit.zero_noise_extrapolation.zne.gen_ZNE_MitEx
 
-.. automethod:: qermit.zero_noise_extrapolation.zne.merge_experiments_task_gen
+.. automethod:: qermit.zero_noise_extrapolation.zne.gen_noise_scaled_mitex
 
 .. autoclass:: qermit.zero_noise_extrapolation.zne.Folding
     :members:
@@ -14,6 +14,8 @@ qermit.zero_noise_extrapolation
     :members:
 
 .. automethod:: qermit.zero_noise_extrapolation.zne.digital_folding_task_gen
+
+.. automethod:: qermit.zero_noise_extrapolation.zne.merge_experiments_task_gen
 
 .. automethod:: qermit.zero_noise_extrapolation.zne.extrapolation_task_gen
 

--- a/docs_src/zero_noise_extrapolation.rst
+++ b/docs_src/zero_noise_extrapolation.rst
@@ -5,6 +5,8 @@ qermit.zero_noise_extrapolation
 
 .. automethod:: qermit.zero_noise_extrapolation.zne.gen_ZNE_MitEx
 
+.. automethod:: qermit.zero_noise_extrapolation.zne.merge_experiments_task_gen
+
 .. autoclass:: qermit.zero_noise_extrapolation.zne.Folding
     :members:
 

--- a/qermit/noise_model/noise_model.py
+++ b/qermit/noise_model/noise_model.py
@@ -222,6 +222,9 @@ class ErrorDistribution:
         :return: Scaled error rate.
         :rtype: float
         """
+        if error_rate == 1:
+            return 1
+
         return 1 - math.exp(scaling_factor * math.log(1 - error_rate))
 
     def scale(self, scaling_factor: float) -> ErrorDistribution:

--- a/qermit/noise_model/noise_model.py
+++ b/qermit/noise_model/noise_model.py
@@ -209,13 +209,25 @@ class ErrorDistribution:
         return fig
 
     @staticmethod
-    def _scale_error_rate(scaling_factor, error_rate):
+    def _scale_error_rate(scaling_factor: float, error_rate: float) -> float:
+        """Assuming error is distributed like Poisson point process, scale
+        error rate.
+
+        :param scaling_factor: The factor by which error rate should be
+            scaled. This is the factor by which the time the Poisson process
+            is acted for should be scaled.
+        :type scaling_factor: float
+        :param error_rate: Original error rate.
+        :type error_rate: float
+        :return: Scaled error rate.
+        :rtype: float
+        """
         return 1 - math.exp(scaling_factor * math.log(1 - error_rate))
 
     def scale(self, scaling_factor: float) -> ErrorDistribution:
         """Generates new ErrorDistribution but with all error rates scaled
         by the given factor. This assumes that errors are distributed like
-        poisson point processes.
+        Poisson point processes.
 
         :param scaling_factor: Factor to scaled error rates by.
         :type scaling_factor: float
@@ -224,7 +236,6 @@ class ErrorDistribution:
         """
         return ErrorDistribution(
             distribution={
-                # error: scaling_factor*error_rate
                 error: self._scale_error_rate(scaling_factor, error_rate)
                 for error, error_rate in self.distribution.items()
             },

--- a/qermit/noise_model/qermit_pauli.py
+++ b/qermit/noise_model/qermit_pauli.py
@@ -632,12 +632,12 @@ class QermitPauli:
         )
 
         return qubit_pauli_string, operator_phase
-    
+
     @classmethod
     def from_pauli_iterable(cls, pauli_iterable: Iterable[Pauli], qubit_list: List[Qubit]) -> QermitPauli:
         return cls(
             Z_list=[int(pauli in (Pauli.Z, Pauli.Y)) for pauli in pauli_iterable],
             X_list=[int(pauli in (Pauli.X, Pauli.Y)) for pauli in pauli_iterable],
             qubit_list=qubit_list,
-            phase=sum(int(pauli==Pauli.Y) for pauli in pauli_iterable) % 4,
+            phase=sum(int(pauli == Pauli.Y) for pauli in pauli_iterable) % 4,
         )

--- a/qermit/noise_model/qermit_pauli.py
+++ b/qermit/noise_model/qermit_pauli.py
@@ -635,6 +635,15 @@ class QermitPauli:
 
     @classmethod
     def from_pauli_iterable(cls, pauli_iterable: Iterable[Pauli], qubit_list: List[Qubit]) -> QermitPauli:
+        """Create a QermitPauli from a Pauli iterable.
+
+        :param pauli_iterable: The Pauli iterable to convert.
+        :type pauli_iterable: Iterable[Pauli]
+        :param qubit_list: The qubits on which the resulting pauli will act.
+        :type qubit_list: List[Qubit]
+        :return: The pauli corresponding to the given iterable.
+        :rtype: QermitPauli
+        """
         return cls(
             Z_list=[int(pauli in (Pauli.Z, Pauli.Y)) for pauli in pauli_iterable],
             X_list=[int(pauli in (Pauli.X, Pauli.Y)) for pauli in pauli_iterable],

--- a/qermit/noise_model/qermit_pauli.py
+++ b/qermit/noise_model/qermit_pauli.py
@@ -5,6 +5,7 @@ import math
 import numpy as np
 from numpy.random import Generator
 from typing import List, Union, Tuple, Dict
+from collections.abc import Iterable
 
 
 class QermitPauli:
@@ -48,6 +49,31 @@ class QermitPauli:
         self.X_list = {qubit: X for qubit, X in zip(qubit_list, X_list)}
         self.phase = phase
         self.qubit_list = qubit_list
+
+    @staticmethod
+    def commute_coeff(pauli_one: QermitPauli, pauli_two: QermitPauli) -> int:
+        """Calculate the coefficient which result from commuting pauli_one
+        past pauli_two. That is to say P_2 P_1 = c P_1 P_2 where c is the
+        coefficient returned by this function.
+
+        :param pauli_one: First Pauli
+        :type pauli_one: QermitPauli
+        :param pauli_two: Second Pauli
+        :type pauli_two: QermitPauli
+        :raises Exception: Raised if the Paulis do not act
+            on matching qubits.
+        :return: Coefficient resulting from commuting the two Paulis.
+        :rtype: int
+        """
+        if not pauli_one.qubit_list == pauli_two.qubit_list:
+            raise Exception(
+                "The given Paulis must act on the same qubits. "
+                + f"In this case the qubits acted on by pauli_one {pauli_one.qubit_list} "
+                + f"differ from those of pauli_two {pauli_two.qubit_list}."
+            )
+        power = sum(pauli_one.X_list[qubit] * pauli_two.Z_list[qubit] for qubit in pauli_one.qubit_list)
+        power += sum(pauli_one.Z_list[qubit] * pauli_two.X_list[qubit] for qubit in pauli_one.qubit_list)
+        return (-1) ** power
 
     def is_measureable(self, qubit_list: List[Qubit]) -> bool:
         """Checks if this Pauli would be measurable on the given qubits in the
@@ -592,7 +618,7 @@ class QermitPauli:
 
     @property
     def qubit_pauli_string(self) -> Tuple[QubitPauliString, complex]:
-        """Qubit pauli string corresponding to Paulii,
+        """Qubit pauli string corresponding to Pauli,
         along with the appropriate phase.
 
         :return: Pauli string and phase corresponding to Pauli.
@@ -606,3 +632,12 @@ class QermitPauli:
         )
 
         return qubit_pauli_string, operator_phase
+    
+    @classmethod
+    def from_pauli_iterable(cls, pauli_iterable: Iterable[Pauli], qubit_list: List[Qubit]) -> QermitPauli:
+        return cls(
+            Z_list=[int(pauli in (Pauli.Z, Pauli.Y)) for pauli in pauli_iterable],
+            X_list=[int(pauli in (Pauli.X, Pauli.Y)) for pauli in pauli_iterable],
+            qubit_list=qubit_list,
+            phase=sum(int(pauli==Pauli.Y) for pauli in pauli_iterable) % 4,
+        )

--- a/qermit/noise_model/transpiler_backend.py
+++ b/qermit/noise_model/transpiler_backend.py
@@ -59,7 +59,7 @@ class TranspilerBackend:
         return CustomPass(transform=transform)
 
     def rebase_pass(self):
-        
+
         def transform(circuit: Circuit) -> Circuit:
             return circuit
 

--- a/qermit/noise_model/transpiler_backend.py
+++ b/qermit/noise_model/transpiler_backend.py
@@ -6,6 +6,7 @@ import uuid
 from pytket.passes import BasePass, CustomPass
 from typing import Dict, List, Optional, Iterator, Sequence, Iterable
 from pytket import Circuit, Bit
+from pytket.backends.resulthandle import ResultHandle
 
 
 class TranspilerBackend:
@@ -25,14 +26,14 @@ class TranspilerBackend:
 
     transpiler: BasePass
     max_batch_size: int
-    result_dict: Dict[uuid.UUID, BackendResult]
+    result_dict: Dict[ResultHandle, BackendResult]
     backend = AerBackend()
 
     def __init__(
         self,
         transpiler: BasePass,
         max_batch_size: int = 100,
-        result_dict: Dict[uuid.UUID, BackendResult] = {},
+        result_dict: Dict[ResultHandle, BackendResult] = {},
     ):
         """Initialisation method.
 
@@ -43,7 +44,7 @@ class TranspilerBackend:
         :type max_batch_size: int, optional
         :param result_dict: Results dictionary, may be used to store existing
             results within backend, defaults to {}
-        :type result_dict: Dict[uuid.UUID, BackendResult], optional
+        :type result_dict: Dict[ResultHandle, BackendResult], optional
         """
 
         self.transpiler = transpiler
@@ -82,7 +83,7 @@ class TranspilerBackend:
         self,
         circuits: Sequence[Circuit],
         n_shots: Sequence[int],
-    ) -> List[uuid.UUID]:
+    ) -> List[ResultHandle]:
 
         return [
             self.process_circuit(circuit=circuit, n_shots=n)
@@ -94,7 +95,7 @@ class TranspilerBackend:
         circuit: Circuit,
         n_shots: int,
         **kwargs,
-    ) -> uuid.UUID:
+    ) -> ResultHandle:
         """[summary]
 
         :param circuit: Submits circuit to run on noisy backend.
@@ -102,10 +103,10 @@ class TranspilerBackend:
         :param n_shots: Number of shots to take from circuit.
         :type n_shots: int
         :return: Handle identifying results in `result_dict`.
-        :rtype: uuid.UUID
+        :rtype: ResultHandle
         """
 
-        handle = uuid.uuid4()
+        handle = ResultHandle(str(uuid.uuid4()))
 
         counts = self.get_counts(
             circuit=circuit,
@@ -123,16 +124,16 @@ class TranspilerBackend:
 
         return handle
 
-    def get_results(self, handles: Iterable[uuid.UUID]) -> List[BackendResult]:
+    def get_results(self, handles: Iterable[ResultHandle]) -> List[BackendResult]:
         return [
             self.get_result(handle) for handle in handles
         ]
 
-    def get_result(self, handle: uuid.UUID) -> BackendResult:
+    def get_result(self, handle: ResultHandle) -> BackendResult:
         """Retrieve result from backend.
 
         :param handle: Handle identifying result.
-        :type handle: uuid.UUID
+        :type handle: ResultHandle
         :return: Result corresponding to handle.
         :rtype: BackendResult
         """

--- a/qermit/noise_model/transpiler_backend.py
+++ b/qermit/noise_model/transpiler_backend.py
@@ -53,17 +53,11 @@ class TranspilerBackend:
 
     def default_compilation_pass(self, **kwargs) -> BasePass:
 
-        def transform(circuit: Circuit) -> Circuit:
-            return circuit
+        return CustomPass(transform=lambda circuit: circuit)
 
-        return CustomPass(transform=transform)
+    def rebase_pass(self) -> BasePass:
 
-    def rebase_pass(self):
-
-        def transform(circuit: Circuit) -> Circuit:
-            return circuit
-
-        return CustomPass(transform=transform)
+        return CustomPass(transform=lambda circuit: circuit)
 
     def run_circuit(
         self,

--- a/qermit/noise_model/transpiler_backend.py
+++ b/qermit/noise_model/transpiler_backend.py
@@ -53,11 +53,13 @@ class TranspilerBackend:
         self.result_dict = result_dict
 
     def default_compilation_pass(self, **kwargs) -> BasePass:
-
+        """Return a compiler pass which has no affect on the circuit.
+        """
         return CustomPass(transform=lambda circuit: circuit)
 
     def rebase_pass(self) -> BasePass:
-
+        """Return a compiler pass which has no affect on the circuit.
+        """
         return CustomPass(transform=lambda circuit: circuit)
 
     def run_circuit(
@@ -84,6 +86,17 @@ class TranspilerBackend:
         circuits: Sequence[Circuit],
         n_shots: Sequence[int],
     ) -> List[ResultHandle]:
+        """Processes a collection of circuits by making use multiple calls
+        to process_circuit.
+
+        :param circuits: A collection of circuit to run.
+        :type circuits: Sequence[Circuit]
+        :param n_shots: The number of shots which should be taken from
+            each circuit.
+        :type n_shots: Sequence[int]
+        :return: The result handle for each circuit.
+        :rtype: List[ResultHandle]
+        """
 
         return [
             self.process_circuit(circuit=circuit, n_shots=n)
@@ -125,6 +138,13 @@ class TranspilerBackend:
         return handle
 
     def get_results(self, handles: Iterable[ResultHandle]) -> List[BackendResult]:
+        """Get the results corresponding to a collection of result handles.
+
+        :param handles: A collection of handles to retrieve.
+        :type handles: Iterable[ResultHandle]
+        :return: The results corresponding to the given collection of
+        :rtype: List[BackendResult]
+        """
         return [
             self.get_result(handle) for handle in handles
         ]

--- a/qermit/spam/spam_mitres.py
+++ b/qermit/spam/spam_mitres.py
@@ -101,6 +101,10 @@ def gen_UnCorrelated_SPAM_MitRes(
     """
     if backend.backend_info is None:
         raise ValueError("Backend has no backend_info attribute.")
+    if backend.backend_info.architecture is None:
+        raise ValueError(
+            "Backend Architecture has no specified Nodes, please use a Backend with a specified Architecture."
+        )
     if len(backend.backend_info.architecture.nodes) == 0:
         raise ValueError(
             "Backend Architecture has no specified Nodes, please use a Backend with a specified Architecture."

--- a/qermit/spam/spam_mitres.py
+++ b/qermit/spam/spam_mitres.py
@@ -103,7 +103,8 @@ def gen_UnCorrelated_SPAM_MitRes(
         raise ValueError("Backend has no backend_info attribute.")
     if backend.backend_info.architecture is None:
         raise ValueError(
-            "Backend Architecture has no specified Nodes, please use a Backend with a specified Architecture."
+            "BackendInfo stored by Backend has no defined Architecture, "
+            + "please use a Backend with a specified Architecture."
         )
     if len(backend.backend_info.architecture.nodes) == 0:
         raise ValueError(

--- a/qermit/zero_noise_extrapolation/zne.py
+++ b/qermit/zero_noise_extrapolation/zne.py
@@ -420,10 +420,10 @@ class Folding(Enum):
         :type n_noisy_circuit_samples: int
         """
 
-        noise_model = kwargs.get("noise_model", NoiseModel(noise_model={}))
-        n_noisy_circuit_samples = kwargs.get("n_noisy_circuit_samples", 1)
+        noise_model: NoiseModel = kwargs.get("noise_model", NoiseModel(noise_model={}))
+        n_noisy_circuit_samples: int = kwargs.get("n_noisy_circuit_samples", 1)
 
-        scaled_noise_model = noise_model.scale(scaling_factor=noise_scaling - 1)
+        scaled_noise_model: NoiseModel = noise_model.scale(scaling_factor=noise_scaling - 1)
         error_transpiler = PauliErrorTranspile(noise_model=scaled_noise_model)
 
         scaled_circ_list = []
@@ -828,12 +828,13 @@ def merge_experiments_task_gen() -> MitTask:
                 for qps, coeff in merged_qpo_dict.items()
             }
 
-        # Convert the dictionary to a list.
-        merged_qpo_list = [QubitPauliOperator({})] * (max(experiment_index_list) + 1)
-        for index in experiment_index_list:
-            merged_qpo_list[index] = QubitPauliOperator(dictionary=index_to_merged_qpo_dict[index])
-
-        return (merged_qpo_list, )
+        # Convert the dictionary to a list and return.
+        return (
+            [
+                QubitPauliOperator(dictionary=index_to_merged_qpo_dict.get(index, {}))
+                for index in range(max(experiment_index_list) + 1)
+            ],
+        )
 
     return MitTask(_label="MergeExperiments", _n_in_wires=2, _n_out_wires=1, _method=task)
 

--- a/tests/noise_model_test.py
+++ b/tests/noise_model_test.py
@@ -722,6 +722,30 @@ def test_is_measureable() -> None:
     assert not stab.is_measureable(qubit_list=[Qubit(name='B', index=0)])
 
 
+def test_noise_model_scaling() -> None:
+
+    error_distribution = ErrorDistribution(
+        distribution={
+            (Pauli.X, Pauli.I): 0.1,
+            (Pauli.Z, Pauli.I): 0.01,
+        }
+    )
+    noise_model = NoiseModel(
+        noise_model={
+            OpType.CZ: error_distribution,
+            OpType.CX: error_distribution
+        }
+    )
+
+    two_scaled_noise_model = noise_model.scale(scaling_factor=2)
+    assert abs(two_scaled_noise_model.noise_model[OpType.CZ].distribution[(Pauli.X, Pauli.I)] - 0.19) < 0.001
+    assert abs(two_scaled_noise_model.noise_model[OpType.CZ].distribution[(Pauli.Z, Pauli.I)] - 0.02) < 0.001
+
+    zero_scaled_noise_model = noise_model.scale(scaling_factor=0)
+    assert abs(zero_scaled_noise_model.noise_model[OpType.CX].distribution[(Pauli.X, Pauli.I)]) < 0.01
+    assert abs(zero_scaled_noise_model.noise_model[OpType.CX].distribution[(Pauli.Z, Pauli.I)]) < 0.01
+
+
 if __name__ == "__main__":
 
     test_is_measureable()

--- a/tests/noise_model_test.py
+++ b/tests/noise_model_test.py
@@ -21,7 +21,7 @@ from qermit.noise_model.noise_model import Direction
 def test_to_ptm() -> None:
 
     # A simple test with an only X noise model on one qubit
-    error_distribution = ErrorDistribution(distribution={(Pauli.X,):0.1})
+    error_distribution = ErrorDistribution(distribution={(Pauli.X,): 0.1})
     ptm, pauli_index = error_distribution.to_ptm()
 
     assert ptm[pauli_index[(Pauli.I, )]][pauli_index[(Pauli.I, )]] == 1
@@ -32,8 +32,8 @@ def test_to_ptm() -> None:
     # A slightly more complicated example with some verified entries.
     error_distribution = ErrorDistribution(
         distribution={
-            (Pauli.X, Pauli.Z):0.08,
-            (Pauli.Y, Pauli.Z):0.02,
+            (Pauli.X, Pauli.Z): 0.08,
+            (Pauli.Y, Pauli.Z): 0.02,
         }
     )
 
@@ -44,13 +44,14 @@ def test_to_ptm() -> None:
     assert abs(ptm[pauli_index[(Pauli.X, Pauli.Z)]][pauli_index[(Pauli.X, Pauli.Z)]] - 0.96) < 10**(-6)
     assert abs(ptm[pauli_index[(Pauli.X, Pauli.X)]][pauli_index[(Pauli.X, Pauli.X)]] - 0.84) < 10**(-6)
 
+
 def test_from_ptm() -> None:
 
     # Test that the error distribution to and from ptm is the same as the initial
-    distribution={
-        (Pauli.X, Pauli.X):0.1,
-        (Pauli.Y, Pauli.Z):0.2,
-        (Pauli.Z, Pauli.X):0.3,
+    distribution = {
+        (Pauli.X, Pauli.X): 0.1,
+        (Pauli.Y, Pauli.Z): 0.2,
+        (Pauli.Z, Pauli.X): 0.3,
     }
 
     error_distribution = ErrorDistribution(
@@ -82,7 +83,8 @@ def test_qermit_pauli_from_iterable() -> None:
         pauli_iterable=qubit_pauli_string.map.values(),
         qubit_list=list(qubit_pauli_string.map.keys())
     )
-    pauli.qubit_pauli_string == (qubit_pauli_string, 1+0j)
+    pauli.qubit_pauli_string == (qubit_pauli_string, 1 + 0j)
+
 
 def test_qermit_pauli_commute_coeff() -> None:
 
@@ -103,7 +105,7 @@ def test_qermit_pauli_commute_coeff() -> None:
     ]
 
     for verified in verified_list:
-        
+
         n_qubits = len(verified[0][0][0])
 
         pauli_one = QermitPauli(Z_list=verified[0][0][0], X_list=verified[0][0][1], qubit_list=[Qubit(i) for i in range(n_qubits)])

--- a/tests/pec_test.py
+++ b/tests/pec_test.py
@@ -50,9 +50,9 @@ REASON = "IBMQ account not configured"
 def test_no_qubit_relabel():
 
     noiseless_backend = AerBackend()
-    lagos_backend = IBMQEmulatorBackend("ibmq_mumbai")
+    mumbai_backend = IBMQEmulatorBackend("ibmq_mumbai")
     pec_mitex = gen_PEC_learning_based_MitEx(
-        device_backend=lagos_backend, simulator_backend=noiseless_backend
+        device_backend=mumbai_backend, simulator_backend=noiseless_backend
     )
 
     c = Circuit(3)

--- a/tests/pec_test.py
+++ b/tests/pec_test.py
@@ -50,9 +50,7 @@ REASON = "IBMQ account not configured"
 def test_no_qubit_relabel():
 
     noiseless_backend = AerBackend()
-    lagos_backend = IBMQEmulatorBackend(
-        "ibm_lagos", instance='partner-cqc/internal/default'
-    )
+    lagos_backend = IBMQEmulatorBackend("ibmq_mumbai")
     pec_mitex = gen_PEC_learning_based_MitEx(
         device_backend=lagos_backend, simulator_backend=noiseless_backend
     )

--- a/tests/zne_test.py
+++ b/tests/zne_test.py
@@ -378,7 +378,7 @@ def test_folding_compiled_circuit():
     )
 
     assert task_1.n_in_wires == 1
-    assert task_1.n_out_wires == 1
+    assert task_1.n_out_wires == 2
 
     c_1 = Circuit(1).Rz(3.5, 0)
     c_1 = emulator_backend.get_compiled_circuit(c_1)
@@ -424,13 +424,13 @@ def test_digital_folding_task_gen():
     )
 
     assert task_1.n_in_wires == 1
-    assert task_1.n_out_wires == 1
+    assert task_1.n_out_wires == 2
     assert task_2.n_in_wires == 1
-    assert task_2.n_out_wires == 1
+    assert task_2.n_out_wires == 2
     assert task_3.n_in_wires == 1
-    assert task_3.n_out_wires == 1
+    assert task_3.n_out_wires == 2
     assert task_4.n_in_wires == 1
-    assert task_4.n_out_wires == 1
+    assert task_4.n_out_wires == 2
 
     c_1 = Circuit(2).CZ(0, 1).T(1)
     c_2 = Circuit(2).CZ(0, 1).T(0).X(1)
@@ -600,7 +600,7 @@ def test_circuit_folding_TK1():
     circ.add_gate(OpType.TK1, (0, 0.1, 0), [0])
     circ.CX(0, 1)
 
-    folded_circ = Folding.circuit(circ, 3)
+    folded_circ = Folding.circuit(circ, 3)[0]
 
     circ_unitary = circ.get_unitary()
     folded_circ_unitary = folded_circ.get_unitary()
@@ -610,7 +610,7 @@ def test_circuit_folding_TK1():
 def test_odd_gate_folding():
 
     circ = Circuit(2).CX(0, 1).X(0).CX(1, 0).X(1)
-    folded_circ = Folding.odd_gate(circ, 2)
+    folded_circ = Folding.odd_gate(circ, 2)[0]
     correct_folded_circ = (
         Circuit(2)
         .CX(0, 1)
@@ -629,7 +629,7 @@ def test_odd_gate_folding():
     assert folded_circ == correct_folded_circ
 
     circ = Circuit(3).CX(0, 1).CX(1, 2)
-    folded_circ = Folding.odd_gate(circ, 3)
+    folded_circ = Folding.odd_gate(circ, 3)[0]
     correct_folded_circ = (
         Circuit(3)
         .CX(0, 1)
@@ -668,11 +668,11 @@ def test_two_qubit_gate_folding():
     )
 
     assert task_1.n_in_wires == 1
-    assert task_1.n_out_wires == 1
+    assert task_1.n_out_wires == 2
     assert task_2.n_in_wires == 1
-    assert task_2.n_out_wires == 1
+    assert task_2.n_out_wires == 2
     assert task_invalid.n_in_wires == 1
-    assert task_invalid.n_out_wires == 1
+    assert task_invalid.n_out_wires == 2
 
     c_1 = Circuit(2).Rz(0.3, 0).ZZPhase(0.3, 1, 0)
     # This is to ensure that the barrier is not folded, even though it

--- a/tests/zne_test.py
+++ b/tests/zne_test.py
@@ -49,6 +49,7 @@ from qermit.taskgraph import gen_MeasurementReduction_MitEx
 from qermit.noise_model import NoiseModel, ErrorDistribution
 from qermit.zero_noise_extrapolation.zne import gen_noise_scaled_mitex
 from qermit.noise_model import TranspilerBackend, PauliErrorTranspile
+from itertools import product
 
 n_qubits = 2
 
@@ -843,6 +844,66 @@ def test_end_to_end_noise_scaled_mitex():
     assert abs(qubit_pauli_operator_list[1]._dict[qps_noisless_one] - 1) < 0.1
     assert abs(qubit_pauli_operator_list[1]._dict[qps_noisless_zero]) < 0.1
 
+@pytest.mark.high_compute
+def test_end_to_end_noise_aware_zne_mitex_starting_from_ptm() -> None:
+
+    # Here we are creating the PTM for a noise model acting
+    # XI with rate 0.1
+    ptm = np.diag([1,1,1,1,1,1,1,1,0.8,0.8,0.8,0.8,0.8,0.8,0.8,0.8])
+    pauli_index = {pauli: index for index, pauli in enumerate(product([Pauli.I, Pauli.X, Pauli.Y, Pauli.Z], repeat=2))}
+    error_distribution = ErrorDistribution.from_ptm(ptm, pauli_index)
+
+    noise_model = NoiseModel(
+        noise_model={
+            OpType.CZ:error_distribution
+        }
+    )
+    transpiler = PauliErrorTranspile(noise_model=noise_model)
+    backend = TranspilerBackend(transpiler=transpiler)
+
+    # Here we perform ZNE with some unevenly spaced
+    # noise scaling values.
+    zne_mitex = gen_ZNE_MitEx(
+        backend=backend,
+        noise_scaling_list=[3.6, 1, 4, 2, 2.5, 3, 3.3],
+        folding_type=Folding.noise_aware,
+        fit_type=Fit.exponential,
+        noise_model=noise_model,
+        n_noisy_circuit_samples=1000,
+    )
+
+    circuit_noisy = Circuit(2).CZ(0,1)
+
+    qps_noisy_noisy = QubitPauliString(map={Qubit(0):Pauli.Z, Qubit(1):Pauli.Z})
+
+    qubit_pauli_operator_noisy = QubitPauliOperator(
+        dictionary = {
+            qps_noisy_noisy:1,
+        }
+    )
+
+    observable_tracker_noisy = ObservableTracker(
+        qubit_pauli_operator=qubit_pauli_operator_noisy
+    )
+
+    shots=10000
+    ansatz_circuit_noisy = AnsatzCircuit(
+        Circuit=circuit_noisy,
+        Shots=shots,
+        SymbolsDict={}
+    )
+
+    observable_experiment_noisy = ObservableExperiment(
+        AnsatzCircuit=ansatz_circuit_noisy,
+        ObservableTracker=observable_tracker_noisy,
+    )
+
+    qubit_pauli_operator_list = zne_mitex.run(
+        mitex_wires=[observable_experiment_noisy]
+    )
+
+    assert abs(qubit_pauli_operator_list[0]._dict[qps_noisy_noisy] - 1) < 0.1
+
 
 @pytest.mark.high_compute
 def test_end_to_end_noise_aware_zne_mitex():
@@ -912,7 +973,6 @@ def test_noise_aware_folding():
         noise_model=noise_model,
         n_noisy_circuit_samples=1,
     )
-    scaled_circ[0]
     assert scaled_circ[0] == Circuit(2).CZ(0, 1).X(0, opgroup='noisy')
 
 

--- a/tests/zne_test.py
+++ b/tests/zne_test.py
@@ -1015,5 +1015,6 @@ if __name__ == "__main__":
     test_gen_initial_compilation_task_quantinuum_qubit_names()
     test_end_to_end_noise_scaled_mitex()
     test_end_to_end_noise_aware_zne_mitex()
+    test_end_to_end_noise_aware_zne_mitex_starting_from_ptm()
     test_merge_experiments_task_gen()
     test_noise_aware_folding()

--- a/tests/zne_test.py
+++ b/tests/zne_test.py
@@ -844,18 +844,19 @@ def test_end_to_end_noise_scaled_mitex():
     assert abs(qubit_pauli_operator_list[1]._dict[qps_noisless_one] - 1) < 0.1
     assert abs(qubit_pauli_operator_list[1]._dict[qps_noisless_zero]) < 0.1
 
+
 @pytest.mark.high_compute
 def test_end_to_end_noise_aware_zne_mitex_starting_from_ptm() -> None:
 
     # Here we are creating the PTM for a noise model acting
     # XI with rate 0.1
-    ptm = np.diag([1,1,1,1,1,1,1,1,0.8,0.8,0.8,0.8,0.8,0.8,0.8,0.8])
+    ptm = np.diag([1, 1, 1, 1, 1, 1, 1, 1, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8])
     pauli_index = {pauli: index for index, pauli in enumerate(product([Pauli.I, Pauli.X, Pauli.Y, Pauli.Z], repeat=2))}
     error_distribution = ErrorDistribution.from_ptm(ptm, pauli_index)
 
     noise_model = NoiseModel(
         noise_model={
-            OpType.CZ:error_distribution
+            OpType.CZ: error_distribution
         }
     )
     transpiler = PauliErrorTranspile(noise_model=noise_model)
@@ -872,21 +873,19 @@ def test_end_to_end_noise_aware_zne_mitex_starting_from_ptm() -> None:
         n_noisy_circuit_samples=1000,
     )
 
-    circuit_noisy = Circuit(2).CZ(0,1)
+    circuit_noisy = Circuit(2).CZ(0, 1)
 
-    qps_noisy_noisy = QubitPauliString(map={Qubit(0):Pauli.Z, Qubit(1):Pauli.Z})
+    qps_noisy_noisy = QubitPauliString(map={Qubit(0): Pauli.Z, Qubit(1): Pauli.Z})
 
     qubit_pauli_operator_noisy = QubitPauliOperator(
-        dictionary = {
-            qps_noisy_noisy:1,
-        }
+        dictionary={qps_noisy_noisy: 1}
     )
 
     observable_tracker_noisy = ObservableTracker(
         qubit_pauli_operator=qubit_pauli_operator_noisy
     )
 
-    shots=10000
+    shots = 10000
     ansatz_circuit_noisy = AnsatzCircuit(
         Circuit=circuit_noisy,
         Shots=shots,

--- a/tests/zne_test.py
+++ b/tests/zne_test.py
@@ -860,7 +860,6 @@ def test_end_to_end_noise_aware_zne_mitex():
     zne_mitex = gen_ZNE_MitEx(
         backend=backend,
         noise_scaling_list=[2, 5, 3, 1, 4],
-        show_fit=True,
         folding_type=Folding.noise_aware,
         fit_type=Fit.exponential,
         noise_model=noise_model,

--- a/tests/zne_test.py
+++ b/tests/zne_test.py
@@ -142,7 +142,7 @@ def test_measurement_reduction_integration():
 
     folding_type = Folding.two_qubit_gate
     fit_type = Fit.linear
-    noise_scaling_list = [1.5, 2, 2.5, 3, 3.5]
+    noise_scaling_list = [1, 1.5, 2, 2.5, 3, 3.5]
     zne_mitex = gen_ZNE_MitEx(
         backend=backend,
         experiment_mitex=reduction_mitex,
@@ -174,9 +174,7 @@ def test_measurement_reduction_integration():
 @pytest.mark.high_compute
 def test_no_qubit_relabel():
 
-    lagos_backend = IBMQEmulatorBackend(
-        "ibm_lagos", instance='partner-cqc/internal/default'
-    )
+    lagos_backend = IBMQEmulatorBackend("ibmq_mumbai")
     zne_mitex = gen_ZNE_MitEx(backend=lagos_backend, noise_scaling_list=[3, 5, 7])
 
     c = Circuit(3)
@@ -322,11 +320,11 @@ def test_gen_duplication_task():
 
 def test_extrapolation_task_gen():
 
-    n_folds = [2, 3, 4, 5]
+    n_folds = [1, 2, 3, 4, 5]
 
     task = extrapolation_task_gen(n_folds, Fit.polynomial, False, 2)
 
-    assert task.n_in_wires == len(n_folds) + 1
+    assert task.n_in_wires == len(n_folds)
     assert task.n_out_wires == 1
 
     # Defines the function (x/10 - 1)**2
@@ -345,14 +343,11 @@ def test_extrapolation_task_gen():
             {QubitPauliString([Qubit(1)], [Pauli.X]): polyval(noise_level, coef_2)}
         )
 
-    # Expectation results from noise as it is on the device.
-    qpo = [qpo_1(1), qpo_2(1)]
-
     # Expectation values at defined noise scaling
     args = [[qpo_1(i), qpo_2(i)] for i in n_folds]
     args = tuple(args)
 
-    result = task([qpo, *args])[0]
+    result = task(args)[0]
 
     experiment_1_result = result[0]._dict
     experiment_2_result = result[1]._dict
@@ -371,7 +366,7 @@ def test_extrapolation_task_gen():
 @pytest.mark.high_compute
 def test_folding_compiled_circuit():
 
-    emulator_backend = IBMQEmulatorBackend("ibmq_quito")
+    emulator_backend = IBMQEmulatorBackend("ibmq_mumbai")
 
     n_folds_1 = 3
 
@@ -534,7 +529,7 @@ def test_zne_identity():
 
     me = gen_ZNE_MitEx(
         backend,
-        [7, 5, 3],
+        [1, 7, 5, 3],
         _label="TestZNEMitEx",
         optimisation_level=0,
     )
@@ -559,7 +554,7 @@ def test_simple_run_end_to_end():
 
     me = gen_ZNE_MitEx(
         be,
-        [2, 3, 4],
+        [1, 2, 3, 4],
         _label="TestZNEMitEx",
         optimisation_level=0,
         folding_type=Folding.gate,


### PR DESCRIPTION
Adds noise aware zero noise extrapolation, in particular as a new folding method. There were a couple of changes to other parts of ZNE needed to make this possible:
- ZNE no longer does 'factor 1 folding' (i.e. using the base noise of the device) by default. A MitEx which just scales the noise has been added
- The folding methods may now generate many circuits, for example in this case sampling many noisy circuits. I expect this to be of more general use.

Otherwise, I think I have pushed enums and kwargs too far here. I would like to move to having a Folding base class which other folding methods can inherit from. Their behaviour can be defined when they are initialised, rather than counting on kwargs being passed. The reason I have not done this here is because it would change the API significantly, and make the ZNE section of the manual redundant, so I thought I'd get your approval first.

Here is an example, which is also included in the tests:
```
from pytket import OpType, Circuit
from qermit.noise_model import NoiseModel, PauliErrorTranspile, ErrorDistribution
from pytket.pauli import Pauli
from qermit.noise_model import TranspilerBackend, PauliErrorTranspile
from qermit.zero_noise_extrapolation.zne import gen_ZNE_MitEx, Folding, Fit
from qermit.taskgraph.mittask import ObservableExperiment, AnsatzCircuit
from qermit.taskgraph.utils import ObservableTracker
from pytket.utils import QubitPauliOperator
from pytket.pauli import QubitPauliString
from pytket.unit_id import Qubit
import numpy as np
from itertools import product

# Here we are creating the PTM of an error model
# which acts XI with rate 0.1
ptm = np.diag([1,1,1,1,1,1,1,1,0.8,0.8,0.8,0.8,0.8,0.8,0.8,0.8])
# This index dixtionary maps Paulis to their index in the PTM
pauli_index = {pauli: index for index, pauli in enumerate(product([Pauli.I, Pauli.X, Pauli.Y, Pauli.Z], repeat=2))}
error_distribution = ErrorDistribution.from_ptm(ptm, pauli_index)

# This print will verify the above
print(error_distribution.distribution)

# This error model will act on the CZ gate,
# and will be acted by the backend created below.
noise_model = NoiseModel(
    noise_model={
        OpType.CZ:error_distribution
    }
)
transpiler = PauliErrorTranspile(noise_model=noise_model)
backend = TranspilerBackend(transpiler=transpiler)

# Note that this particular example of ZNE
# will run with unevenly distributed noise
# scaling values.
zne_mitex = gen_ZNE_MitEx(
    backend=backend,
    noise_scaling_list=[3.6, 1, 4, 2, 2.5, 3, 3.3],
    show_fit=True,
    folding_type=Folding.noise_aware,
    fit_type=Fit.exponential,
    noise_model=noise_model,
    n_noisy_circuit_samples=1000,
)

circuit_noisy = Circuit(2).CZ(0,1)

qps_noisy_noisy = QubitPauliString(map={Qubit(0):Pauli.Z, Qubit(1):Pauli.Z})

qubit_pauli_operator_noisy = QubitPauliOperator(
    dictionary = {
        qps_noisy_noisy:1,
    }
)

observable_tracker_noisy = ObservableTracker(
    qubit_pauli_operator=qubit_pauli_operator_noisy
)

shots=10000
ansatz_circuit_noisy = AnsatzCircuit(
    Circuit=circuit_noisy,
    Shots=shots,
    SymbolsDict={}
)

observable_experiment_noisy = ObservableExperiment(
    AnsatzCircuit=ansatz_circuit_noisy,
    ObservableTracker=observable_tracker_noisy,
)

qubit_pauli_operator_list = zne_mitex.run(
    mitex_wires=[observable_experiment_noisy]
)
```
producing:
<img width="566" alt="Screenshot 2024-03-09 at 15 33 26" src="https://github.com/CQCL/Qermit/assets/52407433/c90c9cea-6fb9-47f5-bc9d-a651323aa88a">