### PR TITLE
refactor: Raise error if observable qubits do not feature in circuit.

### DIFF
--- a/qermit/taskgraph/mitex.py
+++ b/qermit/taskgraph/mitex.py
@@ -139,7 +139,8 @@ def filter_observable_tracker_task_gen() -> MitTask:
                     set(circuit.qubits)
                 )
             )
-            # TODO: This check should be done inside ansatz_circuit.
+            # TODO: In a future refactor, this check should be done
+            # inside ObservableExperiment.
             if len(non_existant_qubits) > 0:
                 raise Exception(
                     f"ObservableTracker qubits {non_existant_qubits} are not found in circuit."

--- a/qermit/taskgraph/mitex.py
+++ b/qermit/taskgraph/mitex.py
@@ -134,9 +134,19 @@ def filter_observable_tracker_task_gen() -> MitTask:
             symbols = ansatz_circuit[2]
             observable_tracker = measurement_wire[1]
 
-            # TODO: This check should be done inside ansatz_circuit.
-            if not observable_tracker.contained_in_qubits(qubit_list=circuit.qubits):
-                raise Exception("ObservableTracker qubits are not found in circuit.")
+            non_existant_qubits = (
+                observable_tracker.qubit_pauli_operator.all_qubits.difference(
+                    set(circuit.qubits)
+                )
+            )
+            print("non_existant_qubits: ", non_existant_qubits)
+
+            if len(non_existant_qubits) > 0:
+                # TODO: This check should be done inside ansatz_circuit.
+                # if not observable_tracker.acts_on_qubits(qubit_list=circuit.qubits):
+                raise Exception(
+                    f"ObservableTracker qubits {non_existant_qubits} are not found in circuit."
+                )
 
             # first make sure all observable has some measurement circuit
             strings_for_circuits = observable_tracker.get_empty_strings()

--- a/qermit/taskgraph/mitex.py
+++ b/qermit/taskgraph/mitex.py
@@ -134,6 +134,10 @@ def filter_observable_tracker_task_gen() -> MitTask:
             symbols = ansatz_circuit[2]
             observable_tracker = measurement_wire[1]
 
+            # TODO: This check should be done inside ansatz_circuit.
+            if not observable_tracker.contained_in_qubits(qubit_list=circuit.qubits):
+                raise Exception("ObservableTracker qubits are not found in circuit.")
+
             # first make sure all observable has some measurement circuit
             strings_for_circuits = observable_tracker.get_empty_strings()
             for string in strings_for_circuits:

--- a/qermit/taskgraph/mitex.py
+++ b/qermit/taskgraph/mitex.py
@@ -139,11 +139,8 @@ def filter_observable_tracker_task_gen() -> MitTask:
                     set(circuit.qubits)
                 )
             )
-            print("non_existant_qubits: ", non_existant_qubits)
-
+            # TODO: This check should be done inside ansatz_circuit.
             if len(non_existant_qubits) > 0:
-                # TODO: This check should be done inside ansatz_circuit.
-                # if not observable_tracker.acts_on_qubits(qubit_list=circuit.qubits):
                 raise Exception(
                     f"ObservableTracker qubits {non_existant_qubits} are not found in circuit."
                 )

--- a/qermit/taskgraph/utils.py
+++ b/qermit/taskgraph/utils.py
@@ -19,7 +19,7 @@ from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 from numpy import ndarray
 from pytket.backends.backendresult import BackendResult
-from pytket.circuit import Bit, Circuit
+from pytket.circuit import Bit, Circuit, Qubit
 from pytket.pauli import QubitPauliString
 from pytket.utils import (
     QubitPauliOperator,
@@ -397,6 +397,23 @@ class ObservableTracker:
         :return: All measurement circuits held in ObservableTracker self._measurement_circuits attirbute.
         """
         return self._measurement_circuits
+
+    def contained_in_qubits(self, qubit_list: List[Qubit]) -> bool:
+        """Returns true if the qubits of this observable are contained in
+        the given list of qubits. Returns False otherwise.
+        This can be used to check of this observable
+        is contained in the qubits features in a circuit, for example.
+
+        :param qubit_list: The list of qubits to check. It will be checked
+            if the qubits of this observable are contained in this list.
+        :return: True if the observable qubits are contained in the given list.
+            False otherwise.
+        """
+
+        return all(
+            observable_quibts in qubit_list
+            for observable_quibts in self.qubit_pauli_operator.all_qubits
+        )
 
     def get_expectations(self, results: List[BackendResult]) -> QubitPauliOperator:
         """

--- a/qermit/taskgraph/utils.py
+++ b/qermit/taskgraph/utils.py
@@ -19,7 +19,7 @@ from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 from numpy import ndarray
 from pytket.backends.backendresult import BackendResult
-from pytket.circuit import Bit, Circuit, Qubit
+from pytket.circuit import Bit, Circuit
 from pytket.pauli import QubitPauliString
 from pytket.utils import (
     QubitPauliOperator,

--- a/qermit/taskgraph/utils.py
+++ b/qermit/taskgraph/utils.py
@@ -398,23 +398,6 @@ class ObservableTracker:
         """
         return self._measurement_circuits
 
-    def contained_in_qubits(self, qubit_list: List[Qubit]) -> bool:
-        """Returns true if the qubits of this observable are contained in
-        the given list of qubits. Returns False otherwise.
-        This can be used to check of this observable
-        is contained in the qubits features in a circuit, for example.
-
-        :param qubit_list: The list of qubits to check. It will be checked
-            if the qubits of this observable are contained in this list.
-        :return: True if the observable qubits are contained in the given list.
-            False otherwise.
-        """
-
-        return all(
-            observable_quibts in qubit_list
-            for observable_quibts in self.qubit_pauli_operator.all_qubits
-        )
-
     def get_expectations(self, results: List[BackendResult]) -> QubitPauliOperator:
         """
         For given list of results, returns a QubitPauliOperator giving an expectation for each QubitPauliString

--- a/tests/mitex_test.py
+++ b/tests/mitex_test.py
@@ -15,6 +15,7 @@
 
 import copy
 
+import pytest
 from pytket.circuit import Circuit, OpType, Qubit, fresh_symbol  # type: ignore
 from pytket.extensions.qiskit import AerBackend  # type: ignore
 from pytket.pauli import Pauli, QubitPauliString  # type: ignore
@@ -35,6 +36,45 @@ from qermit.taskgraph.mitex import (  # type: ignore
     get_expectations_task_gen,
     split_results_task_gen,
 )
+
+
+def test_valid_observable():
+    backend = AerBackend(n_qubits=2)
+    mitex = MitEx(backend=backend)
+
+    circuit = Circuit()
+    q_reg = circuit.add_q_register(name="my_quibts", size=2)
+    circuit.CX(q_reg[0], q_reg[1])
+    compiled_circuit = backend.get_compiled_circuit(circuit)
+
+    qps_one = QubitPauliString(
+        [Qubit(name="my_quibts", index=0), Qubit(name="my_quibts", index=1)],
+        [Pauli.Z, Pauli.Z],
+    )
+    qps_two = QubitPauliString([Qubit(1), Qubit(2)], [Pauli.Z, Pauli.Z])
+
+    obs_exp = ObservableExperiment(
+        AnsatzCircuit(compiled_circuit, 2, SymbolsDict()),
+        ObservableTracker(
+            QubitPauliOperator(
+                {
+                    qps_one: 1,
+                }
+            )
+        ),
+    )
+
+    assert mitex.run([obs_exp])[0]._dict[qps_one] == 1.0
+
+    obs_exp = ObservableExperiment(
+        AnsatzCircuit(compiled_circuit, 2, SymbolsDict()),
+        ObservableTracker(QubitPauliOperator({qps_one: 1, qps_two: 1})),
+    )
+    with pytest.raises(
+        Exception,
+        match="ObservableTracker qubits \{q\[2\], q\[1\]\} are not found in circuit.",
+    ):
+        mitex.run([obs_exp])
 
 
 def test_mitex_cache():

--- a/tests/mitex_test.py
+++ b/tests/mitex_test.py
@@ -45,7 +45,6 @@ def test_valid_observable():
     circuit = Circuit()
     q_reg = circuit.add_q_register(name="my_quibts", size=2)
     circuit.CX(q_reg[0], q_reg[1])
-    compiled_circuit = backend.get_compiled_circuit(circuit)
 
     qps_one = QubitPauliString(
         [Qubit(name="my_quibts", index=0), Qubit(name="my_quibts", index=1)],
@@ -54,7 +53,7 @@ def test_valid_observable():
     qps_two = QubitPauliString([Qubit(1), Qubit(2)], [Pauli.Z, Pauli.Z])
 
     obs_exp = ObservableExperiment(
-        AnsatzCircuit(compiled_circuit, 2, SymbolsDict()),
+        AnsatzCircuit(circuit, 2, SymbolsDict()),
         ObservableTracker(
             QubitPauliOperator(
                 {
@@ -67,7 +66,7 @@ def test_valid_observable():
     assert mitex.run([obs_exp])[0]._dict[qps_one] == 1.0
 
     obs_exp = ObservableExperiment(
-        AnsatzCircuit(compiled_circuit, 2, SymbolsDict()),
+        AnsatzCircuit(circuit, 2, SymbolsDict()),
         ObservableTracker(QubitPauliOperator({qps_one: 1, qps_two: 1})),
     )
     with pytest.raises(


### PR DESCRIPTION
I do not know if there is a reason you would want to measure an observable over qubits that dod not exist in a circuit, but this seems like a mistake to me.