### PR TITLE
fix: Correct MitTask type

### DIFF
--- a/qermit/taskgraph/mittask.py
+++ b/qermit/taskgraph/mittask.py
@@ -16,7 +16,7 @@
 from collections import namedtuple
 from enum import Enum
 from types import MethodType
-from typing import Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 from pytket import Bit, Circuit, Qubit
 from pytket.backends import ResultHandle
@@ -98,7 +98,7 @@ class MitTask:
     def n_out_wires(self):
         return self._n_out_wires
 
-    def __call__(self, input_wires: List[Wire]) -> List[Wire]:
+    def __call__(self, input_wires: Tuple[List[Wire]]) -> Tuple[List[Wire]]:
         return self.run(*input_wires)
 
     def __str__(self):


### PR DESCRIPTION
Very minor change. As this change touches everything I though I would double check incase I have misunderstood something.
Is this typing the way we have used MitTask in practice?